### PR TITLE
Add Fish's man directory to `$MANPATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ The colors are added by setting environment variables that control how `less`, `
 
 Credits: This idea was first inspired by [Arch Linux wiki](https://wiki.archlinux.org/index.php/Color_output_in_console#Using_less).
 
-Note: [decors/fish-colored-man](https://github.com/decors/fish-colored-man) is a very similar plugin. The main difference between this one and `fish-colored-man` is that this one
+Note: [decors/fish-colored-man](https://github.com/decors/fish-colored-man) is a very similar plugin. What `colored_man_pages.fish` has but `fish-colored-man` does not:
 
-- makes sure to add fish's man pages to MANPATH so users are able to read man pages for fish builtins
+- adds fish's man pages to MANPATH so users are able to read man pages for fish builtins
 - includes a wrapper to also colorize the output of utilities that rely on less, such as `git help`
+
+Conversely, `fish-colored-man` allows configuring colors but not `colored_man_pages.fish`.
 
 <img alt="colored man page for less" src="./images/less-man-page.png">
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,7 @@ The colors are added by setting environment variables that control how `less`, `
 
 Credits: This idea was first inspired by [Arch Linux wiki](https://wiki.archlinux.org/index.php/Color_output_in_console#Using_less).
 
-Note: [decors/fish-colored-man](https://github.com/decors/fish-colored-man) is a very similar plugin. What `colored_man_pages.fish` has but `fish-colored-man` does not:
-
-- adds fish's man pages to MANPATH so users are able to read man pages for fish builtins
-- includes a wrapper to also colorize the output of utilities that rely on less, such as `git help`
-
-Conversely, `fish-colored-man` allows configuring colors but not `colored_man_pages.fish`.
+Note: [decors/fish-colored-man](https://github.com/decors/fish-colored-man) is a very similar plugin. `colored_man_pages.fish` includes a wrapper to also colorize the output of utilities that rely on less, such as `git help`. Conversely, `fish-colored-man` allows configuring colors.
 
 <img alt="colored man page for less" src="./images/less-man-page.png">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://cdn.rawgit.com/oh-my-fish/oh-my-fish/e4f1c2e0219a17e2c748b824004c8d0b38055c16/docs/logo.svg" align="left" width="144px" height="144px"/>
 
 #### colored_man_pages.fish
+
 > A plugin for the [fish-shell](https://fishshell.com).
 
 [![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE)
@@ -15,31 +16,44 @@ The colors are added by setting environment variables that control how `less`, `
 
 Credits: This idea was first inspired by [Arch Linux wiki](https://wiki.archlinux.org/index.php/Color_output_in_console#Using_less).
 
+Note: [decors/fish-colored-man](https://github.com/decors/fish-colored-man) is a very similar plugin. The main difference between this one and `fish-colored-man` is that this one
+
+- makes sure to add fish's man pages to MANPATH so users are able to read man pages for fish builtins
+- includes a wrapper to also colorize the output of utilities that rely on less, such as `git help`
+
 <img alt="colored man page for less" src="./images/less-man-page.png">
 
 ## Install
 
 With [Oh My Fish]
+
 ```fish
 $ omf install https://github.com/patrickf1/colored_man_pages.fish
 ```
+
 With [fisher]
+
 ```fish
 $ fisher install patrickf1/colored_man_pages.fish
 ```
 
 ## Usage
+
 Just invoke `man` as usual, but without changing the pager, to get colored output. For example
+
 ```fish
 $ man less
 ```
+
 To execute vanilla `man` without colored output, we can bypass the wrapper using `command`. For example
+
 ```fish
 $ command man less
 ```
 
-To colorize the output of utilities that rely on less, use the `cless` wrapper to configure less before executing the utility.
+To colorize the output of utilities that rely on less, use the `cless` (short for colored less) wrapper to configure less before executing the utility.
 For example
+
 ```fish
 $ cless git help merge
 $ cless git help log
@@ -52,5 +66,5 @@ $ cless git help log
 [mit]: https://opensource.org/licenses/MIT
 [omf-link]: https://www.github.com/oh-my-fish/oh-my-fish
 [fisher]: https://github.com/jorgebucaran/fisher
-[Oh My Fish]: https://github.com/oh-my-fish/oh-my-fish
+[oh my fish]: https://github.com/oh-my-fish/oh-my-fish
 [license-badge]: https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square

--- a/functions/man.fish
+++ b/functions/man.fish
@@ -1,3 +1,14 @@
 function man --wraps man -d "Run man with added colors"
-    cless /usr/bin/man $argv
+    set --local --export MANPATH $MANPATH
+
+    if test -z "$MANPATH" && set path (command man -p 2>/dev/null)
+        set MANPATH (string replace --regex '[^/]+$' '' $path)
+    end
+
+    set fish_manpath (dirname $__fish_data_dir)/fish/man
+    if test -d $fish_manpath
+        set --prepend MANPATH $fish_manpath
+    end
+
+    cless (command --search man) $argv
 end

--- a/functions/man.fish
+++ b/functions/man.fish
@@ -1,10 +1,12 @@
 function man --wraps man -d "Run man with added colors"
     set --local --export MANPATH $MANPATH
 
+    # set MANPATH if not already set to ??? TODO
     if test -z "$MANPATH" && set path (command man -p 2>/dev/null)
         set MANPATH (string replace --regex '[^/]+$' '' $path)
     end
 
+    # prepend the directory of fish manpages to MANPATH
     set fish_manpath (dirname $__fish_data_dir)/fish/man
     if test -d $fish_manpath
         set --prepend MANPATH $fish_manpath

--- a/functions/man.fish
+++ b/functions/man.fish
@@ -1,7 +1,8 @@
 function man --wraps man -d "Run man with added colors"
     set --local --export MANPATH $MANPATH
 
-    # set MANPATH if not already set to ??? TODO
+    # special case for NetBSD and FreeBSD: set MANPATH if not already set
+    # see https://github.com/fish-shell/fish-shell/blob/555af37616893160ad1afb208a957d6a01a7a315/share/functions/man.fish#L15
     if test -z "$MANPATH" && set path (command man -p 2>/dev/null)
         set MANPATH (string replace --regex '[^/]+$' '' $path)
     end


### PR DESCRIPTION
If you look closely, you will notice Fish has a `man` function wrapper that adds its man directory to `$MANPATH`. This plugin should preserve this behavior.

Also, assuming `man` is located at `/usr/bin/man` is fine most of the time, but we can do better.