### PR TITLE
Correctly handle empty `MANPATH`

### DIFF
--- a/functions/man.fish
+++ b/functions/man.fish
@@ -1,10 +1,14 @@
 function man --wraps man -d "Run man with added colors"
-    set --local --export MANPATH $MANPATH ''
+    set --local --export MANPATH $MANPATH
 
     # special case for NetBSD and FreeBSD: set MANPATH if not already set
     # see https://github.com/fish-shell/fish-shell/blob/555af37616893160ad1afb208a957d6a01a7a315/share/functions/man.fish#L15
-    if test -z "$MANPATH" && set path (command man -p 2>/dev/null)
-        set MANPATH (string replace --regex '[^/]+$' '' $path)
+    if test -z "$MANPATH"
+        if set path (command man -p 2>/dev/null)
+            set MANPATH (string replace --regex '[^/]+$' '' $path)
+        else
+            set MANPATH ""
+        end
     end
 
     # prepend the directory of fish manpages to MANPATH

--- a/functions/man.fish
+++ b/functions/man.fish
@@ -1,5 +1,5 @@
 function man --wraps man -d "Run man with added colors"
-    set --local --export MANPATH $MANPATH
+    set --local --export MANPATH $MANPATH ''
 
     # special case for NetBSD and FreeBSD: set MANPATH if not already set
     # see https://github.com/fish-shell/fish-shell/blob/555af37616893160ad1afb208a957d6a01a7a315/share/functions/man.fish#L15

--- a/functions/man.fish
+++ b/functions/man.fish
@@ -12,7 +12,7 @@ function man --wraps man -d "Run man with added colors"
     end
 
     # prepend the directory of fish manpages to MANPATH
-    set fish_manpath (dirname $__fish_data_dir)/fish/man
+    set fish_manpath $__fish_data_dir/man
     if test -d $fish_manpath
         set --prepend MANPATH $fish_manpath
     end


### PR DESCRIPTION
Fix #4 

Handle empty `MANPATH` like [Fish](https://github.com/fish-shell/fish-shell/blob/504a969a2471b7e2ed459d7c2b3b026919ce5f3a/share/functions/man.fish) does. It seems man expects something like MANPATH=/usr/local/Cellar/fish/3.2.2_1/share/fish/man: (notice the extra :) to fallback to other man pages. That equals to an extra empty string in fish.

I also took the chance to backport [another change in fish](https://github.com/fish-shell/fish-shell/commit/2cfb4343ed49aa976c8f6e5fc999198c0d873ef7#diff-e2c1373c8715bec537d5247400fe5f8de23eceaa2a1d79b61e90aaaf919c5aaa).